### PR TITLE
changed file excluded by default (why?)

### DIFF
--- a/.github/workflows/ci.semgrep.yml
+++ b/.github/workflows/ci.semgrep.yml
@@ -22,7 +22,7 @@ jobs:
       # Fetch project source with GitHub Actions Checkout.
       - uses: actions/checkout@v3
       # Run the "semgrep ci" command on the command line of the docker image.
-      - run: semgrep ci 
+      - run: semgrep ci --verbose
         env:
            # Add the rules that Semgrep uses by setting the SEMGREP_RULES environment variable. 
            SEMGREP_RULES: .semgrep_rules.yml # more at semgrep.dev/explore

--- a/tests/test_messi.py
+++ b/tests/test_messi.py
@@ -1,0 +1,4 @@
+
+def test_messi():
+    who = "Lionel Messi"
+    assert who is "God"


### PR DESCRIPTION
I want to include test code in the scan. Even when I have a .semgrepignore that doesn't include `tests/` folder (included in the default), it is still excluded because a this path is hardcoded for the `--exclude`  option. 

why ? 
